### PR TITLE
Remove malicious polyfill.io dependency

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -106,7 +106,6 @@ markdown_extensions:
 
 extra_javascript:
   - javascripts/mathjax.js
-  - https://polyfill.io/v3/polyfill.min.js?features=es6
   - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
   - javascripts/autoscroll.js
   - https://w.soundcloud.com/player/api.js


### PR DESCRIPTION
## Summary

Removes the `https://polyfill.io/v3/polyfill.min.js?features=es6` script from `extra_javascript` in `mkdocs.yml`.

The **polyfill.io** CDN domain was sold in mid-2024 to a malicious operator that injected credential-phishing / malicious-redirect code into the served script, affecting an estimated 100,000+ sites. This blog included it as part of the legacy MathJax setup recipe, which means visitors have been served the compromised script.

## Why it's safe to remove

- MathJax 3 (loaded via `tex-mml-chtml.js`) runs natively on all modern browsers; the `es6` polyfill only ever backfilled legacy browsers like IE11.
- The polyfill was **not** required or injected by mkdocs / mkdocs-material — it was a manual line in `mkdocs.yml`.
- MathJax has since removed the polyfill recommendation from its own documentation.

## Verification

- Rebuilt with `mkdocs build`: **0** external `polyfill.io` references and **0** HTML files reference polyfill (remaining matches are only in mkdocs-material's own local search-worker sourcemap — harmless theme internals).
- All 71 math-rendering pages still load MathJax correctly.

## Notes

- The built `site/` is gitignored and deployed to the `deploy` branch, so the malicious script clears on the next deploy.
- Unrelated: `mkdocs-material` is at 9.6.22 vs latest 9.7.6 (the `~= 9.6` pin already permits 9.7.x) — not changed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)