### PR TITLE
Harden third-party JS: add CSP and pin MathJax with SRI

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -106,7 +106,9 @@ markdown_extensions:
 
 extra_javascript:
   - javascripts/mathjax.js
-  - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
+  # MathJax library is injected in overrides/main.html with an exact version
+  # pin + Subresource Integrity hash. mkdocs `extra_javascript` cannot set the
+  # `integrity`/`crossorigin` attributes, so it must be a raw <script> tag.
   - javascripts/autoscroll.js
   - https://w.soundcloud.com/player/api.js
   - javascripts/musicplayer.js

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -2,6 +2,32 @@
 
 {% block site_meta %}
     {{ super() }}
+    {#
+        Content-Security-Policy: restricts which origins may load executable
+        resources, so a third-party CDN going rogue (cf. the polyfill.io
+        supply-chain attack) cannot inject scripts that aren't on this allow
+        list. GitHub Pages can't send HTTP headers, so this is delivered as a
+        <meta> tag. The origin allow lists below were derived empirically from
+        the built site; add an origin here when introducing a new embed/CDN.
+
+        'unsafe-inline' is required because Material for MkDocs ships inline
+        <script>/<style> bootstrap blocks and static hosting cannot mint a
+        per-request nonce. This does NOT weaken the origin allow list: an
+        external <script src> still must match an allowed host, so a new/rogue
+        CDN remains blocked.
+    #}
+    <meta http-equiv="Content-Security-Policy" content="
+        default-src 'self';
+        script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://cdn.plot.ly https://utteranc.es https://w.soundcloud.com https://www.googletagmanager.com;
+        style-src 'self' 'unsafe-inline' https://fonts.googleapis.com;
+        font-src 'self' data: https://fonts.gstatic.com;
+        img-src 'self' data: https:;
+        frame-src https://w.soundcloud.com https://www.youtube.com https://utteranc.es;
+        connect-src 'self' https://www.googletagmanager.com https://www.google-analytics.com https://*.google-analytics.com https://analytics.google.com https://*.analytics.google.com https://utteranc.es;
+        worker-src 'self' blob:;
+        object-src 'none';
+        base-uri 'self';
+    ">
     <meta name="naver-site-verification" content="350e113007a0eb7457df0e7257d064821aadb302" />
     <meta name="google-site-verification" content="a03bDk70M68JfTAtAahtI2Rgnez2v29KYXrRPM0X_to" />
 {% endblock %}
@@ -12,4 +38,19 @@
     {% else %}
         <!-- ANALYTICS IS NOT LOADED. -->
     {% endif %}
+{% endblock %}
+
+{% block scripts %}
+    {{ super() }}
+    {#
+        MathJax library, pinned to an exact version with a Subresource
+        Integrity hash so a tampered CDN response is rejected by the browser.
+        Loaded after super() so the window.MathJax config (javascripts/mathjax.js,
+        rendered via extra_javascript) is already in place. crossorigin is
+        mandatory for SRI to be enforced on a cross-origin script.
+    #}
+    <script
+        src="https://cdn.jsdelivr.net/npm/mathjax@3.2.2/es5/tex-mml-chtml.js"
+        integrity="sha384-Wuix6BuhrWbjDBs24bXrjf4ZQ5aFeFWBuKkFekO2t8xFU0iNaLQfp2K6/1Nxveei"
+        crossorigin="anonymous"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary

Defense-in-depth follow-up to #8 (removing polyfill.io). **Dependabot only scans dependency manifests** (`package.json`, `requirements.txt`), so scripts loaded by raw URL — exactly the polyfill.io case — are invisible to it. This PR closes that blind spot for the whole site.

## Changes

### 1. Content-Security-Policy `<meta>` tag (`overrides/main.html`)
Restricts which origins may load executable resources. **This would have blocked the polyfill.io payload even while that line was still present**, because `polyfill.io` was never on the allow list.

The `script-src` / `frame-src` / `connect-src` / `font-src` allow lists were derived **empirically from the built `site/`**, not guessed:

| Directive | Allowed origins (why) |
|---|---|
| `script-src` | jsDelivr (MathJax), cdn.plot.ly (charts), utteranc.es (comments), w.soundcloud.com (player), googletagmanager (GA) |
| `frame-src` | w.soundcloud.com, www.youtube.com (one post embeds a video), utteranc.es |
| `style-src` / `font-src` | fonts.googleapis.com / fonts.gstatic.com (Material's Google Fonts) |
| `connect-src` | Google Analytics beacon endpoints + utteranc.es |

> `'unsafe-inline'` is included for `script-src`/`style-src` because Material for MkDocs ships inline bootstrap blocks and static hosting (GitHub Pages) cannot mint a per-request nonce. This does **not** weaken the origin allow list — an external `<script src>` must still match an allowed host, so a rogue/new CDN stays blocked.

### 2. MathJax pinned to exact version + SRI
- `mathjax@3` (floating tag) → `mathjax@3.2.2` (latest v3 line).
- Added a `sha384` Subresource Integrity hash (+ `crossorigin`) so a tampered CDN response is rejected by the browser.
- Injected as a raw `<script>` via the Material `scripts` block because mkdocs `extra_javascript` can't set `integrity`. Config (`window.MathJax`) still loads before the library.

## Verification (build-time)
- `mkdocs build` succeeds; CSP meta present on every page; MathJax loads **exactly once**, pinned + SRI; floating `@3` tag and `polyfill.io` both gone.

## ⚠️ Needs local browser testing before merge
CSP runtime effects can't be confirmed from the build alone. Please verify in `mkdocs serve` (DevTools console should show **no CSP violations**):
- [ ] Math renders (e.g. `series/cpp/3`)
- [ ] SoundCloud music player works
- [ ] Utterances comments load
- [ ] Search works (web worker)
- [ ] The YouTube embed plays
- [ ] Google Analytics fires (Network tab)

If any feature breaks, the offending origin just needs adding to the relevant directive. To roll out cautiously, the `http-equiv` value can temporarily be `Content-Security-Policy-Report-Only` to observe violations without enforcing.

## Notes
- GitHub Pages can't set HTTP headers, hence the `<meta>` delivery (note: `frame-ancestors`/`report-uri` are ignored in meta form — not relied upon here).
- Plotly is already exact-pinned in generated `raw_html/`; CSP now also restricts its origin. SRI on those generated files was left out to avoid churn on regeneration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)